### PR TITLE
Replaced erroneous Grave with intended apostrophe

### DIFF
--- a/AdvancedPluginsWiki/abilities/functions.md
+++ b/AdvancedPluginsWiki/abilities/functions.md
@@ -25,7 +25,7 @@ Example:
 
 ```yaml
 effects:
-- 'ADD_HEALTH:5 <condition>%victim health% < 10 : %allow%</condition>`
+- 'ADD_HEALTH:5 <condition>%victim health% < 10 : %allow%</condition>'
 ```
 
 This would add 2.5 hearts to victim's health if they had less than 5 hearts remaining.


### PR DESCRIPTION
Replaced an erroneous Grave (`) where an apostrophe was intended. Was causing a break in the example code.